### PR TITLE
Remove go 1.5 testing, its old and obsolete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 addons:
   mariadb: '10.1'
 go:
-  - 1.5
   - tip
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Remove go 1.5 testing, its old and obsolete