### PR TITLE
add 'order by ordinal_position asc' to ensure the correct order

### DIFF
--- a/utils_mysql.go
+++ b/utils_mysql.go
@@ -31,7 +31,7 @@ func GetColumnsFromMysqlTable(mariadbUser string, mariadbPassword string, mariad
 	// Store colum as map of maps
 	columnDataTypes := make(map[string]map[string]string)
 	// Select columnd data from INFORMATION_SCHEMA
-	columnDataTypeQuery := "SELECT COLUMN_NAME, COLUMN_KEY, DATA_TYPE, IS_NULLABLE, COLUMN_COMMENT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND table_name = ?"
+	columnDataTypeQuery := "SELECT COLUMN_NAME, COLUMN_KEY, DATA_TYPE, IS_NULLABLE, COLUMN_COMMENT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND table_name = ? order by ordinal_position asc"
 
 	if Debug {
 		fmt.Println("running: " + columnDataTypeQuery)


### PR DESCRIPTION
sometimes the data queryed from  INFORMATION_SCHEMA.COLUMNS  returns the wrong order , add 'order by ordinal_position asc' to ensure the correct order 